### PR TITLE
Auto-sync fork with upstream CyberDrain/CIPP on a daily schedule

### DIFF
--- a/.github/workflows/azure-static-web-apps-wonderful-mud-0d3695c1e.yml
+++ b/.github/workflows/azure-static-web-apps-wonderful-mud-0d3695c1e.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: # allows the upstream sync workflow (and you) to start a deploy manually
 #  pull_request:
 #    types: [opened, synchronize, reopened, closed]
 #    branches:
@@ -11,7 +12,7 @@ on:
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:

--- a/.github/workflows/sync_upstream.yml
+++ b/.github/workflows/sync_upstream.yml
@@ -1,0 +1,63 @@
+name: Sync Fork with Upstream CIPP
+
+# Automatically pulls new commits from the upstream CyberDrain/CIPP repository
+# into this fork (the same thing as clicking "Sync fork" in the GitHub UI),
+# then kicks off the Azure Static Web Apps deploy so the update goes live.
+#
+# Runs on a daily schedule and can also be run manually from the Actions tab.
+#
+# OPTIONAL BUT RECOMMENDED: add a repository secret named SYNC_PAT containing
+# a fine-grained personal access token for this repository with
+# "Contents: Read and write" and "Workflows: Read and write" permissions.
+# Without it the sync still works, but it will fail on the (rare) occasions
+# that upstream changes files under .github/workflows/, because the default
+# Actions token is not allowed to update workflow files.
+
+on:
+  schedule:
+    - cron: "23 5 * * *" # daily at 05:23 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency: sync-upstream
+
+jobs:
+  sync:
+    name: Pull upstream changes
+    runs-on: ubuntu-latest
+    env:
+      HAS_SYNC_PAT: ${{ secrets.SYNC_PAT != '' }}
+    steps:
+      - name: Sync default branch with upstream
+        id: sync
+        env:
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! RESPONSE=$(gh api "repos/${{ github.repository }}/merge-upstream" -f branch="${{ github.ref_name }}" 2>&1); then
+            echo "$RESPONSE"
+            echo "::error::Sync from upstream failed. If the error mentions workflow files or permissions, add a SYNC_PAT repository secret (fine-grained PAT with Contents and Workflows read/write on this repo). If it mentions a merge conflict, sync once manually with GitHub's 'Sync fork' button, then this workflow will take over again."
+            exit 1
+          fi
+          echo "$RESPONSE"
+          MERGE_TYPE=$(echo "$RESPONSE" | jq -r '.merge_type // "none"')
+          if [ "$MERGE_TYPE" = "none" ]; then
+            echo "Already up to date with upstream."
+            echo "merged=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Merged new upstream commits (merge type: $MERGE_TYPE)."
+            echo "merged=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # A push made with the default Actions token does not trigger other
+      # workflows, so the deploy has to be started explicitly. When SYNC_PAT
+      # is configured the push triggers the deploy on its own, so this step
+      # is skipped.
+      - name: Trigger Azure Static Web Apps deploy
+        if: steps.sync.outputs.merged == 'true' && env.HAS_SYNC_PAT != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run azure-static-web-apps-wonderful-mud-0d3695c1e.yml --ref "${{ github.ref_name }}"


### PR DESCRIPTION
## What this does

Automates the manual "Sync fork" step you've been doing every time CIPP shows the out-of-date warning. Once merged:

1. **`.github/workflows/sync_upstream.yml`** (new) runs **daily at 05:23 UTC** (and on demand from the Actions tab). It calls GitHub's merge-upstream API — the exact same operation as clicking **Sync fork** — to pull new commits from `CyberDrain/CIPP` into `main`.
2. If new commits came in, your existing **Azure Static Web Apps deploy** runs automatically, so the update goes live with no manual steps.

The deploy workflow (`azure-static-web-apps-wonderful-mud-0d3695c1e.yml`) gets a small tweak: a `workflow_dispatch` trigger, so the sync workflow can start a deploy directly. This is needed because pushes made with the default Actions token don't trigger other workflows on their own.

## Recommended one-time setup (optional but makes it bulletproof)

Out of the box this works with the built-in Actions token, **but** GitHub blocks that token from updating files under `.github/workflows/`. CIPP occasionally changes its workflow files upstream, and on those days the sync run will fail until synced manually once. To avoid that entirely:

1. Create a **fine-grained personal access token** (GitHub → Settings → Developer settings → Fine-grained tokens) scoped to this repository, with **Contents: Read and write** and **Workflows: Read and write** permissions.
2. Add it to this repo as a secret named **`SYNC_PAT`** (repo → Settings → Secrets and variables → Actions).

When `SYNC_PAT` is present, the sync uses it and the deploy triggers naturally off the push.

## Notes

- Schedule is the `cron: "23 5 * * *"` line in `sync_upstream.yml` — adjust freely (e.g. `"23 */6 * * *"` for every 6 hours).
- If upstream ever conflicts with the fork (unlikely since this fork carries no custom code changes), the run fails with a clear error telling you to do one manual Sync fork, after which automation resumes.
- Your `O-Netrix/CIPP-API` fork has the same problem — the identical workflow can be dropped in there (its deploy pushes to the Azure Function App). Happy to do that in a follow-up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QqsuHkTDbDMZtGzV1oLEUD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QqsuHkTDbDMZtGzV1oLEUD)_